### PR TITLE
feat: implement project detector

### DIFF
--- a/src/main/java/com/falniak/devdoctor/commands/DetectCommand.java
+++ b/src/main/java/com/falniak/devdoctor/commands/DetectCommand.java
@@ -1,5 +1,8 @@
 package com.falniak.devdoctor.commands;
 
+import com.falniak.devdoctor.detect.DetectionResult;
+import com.falniak.devdoctor.detect.ProjectDetector;
+import com.falniak.devdoctor.detect.ProjectType;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -22,7 +25,18 @@ public class DetectCommand implements Runnable {
     @Override
     public void run() {
         Path targetPath = Paths.get(path).toAbsolutePath().normalize();
-        System.out.println("Target path: " + targetPath);
-        System.out.println("Not implemented yet");
+        ProjectDetector detector = new ProjectDetector();
+        DetectionResult result = detector.detect(targetPath);
+
+        System.out.println("Project root: " + result.root());
+        System.out.println("Detected types:");
+        
+        if (result.types().isEmpty()) {
+            System.out.println("  None");
+        } else {
+            for (ProjectType type : result.types()) {
+                System.out.println("  " + type);
+            }
+        }
     }
 }

--- a/src/main/java/com/falniak/devdoctor/detect/DetectionResult.java
+++ b/src/main/java/com/falniak/devdoctor/detect/DetectionResult.java
@@ -1,0 +1,19 @@
+package com.falniak.devdoctor.detect;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Represents the result of project detection.
+ *
+ * @param root The detected project root directory
+ * @param types The set of detected project types
+ * @param markersFound The list of marker files that were found
+ */
+public record DetectionResult(
+    Path root,
+    Set<ProjectType> types,
+    List<String> markersFound
+) {
+}

--- a/src/main/java/com/falniak/devdoctor/detect/ProjectDetector.java
+++ b/src/main/java/com/falniak/devdoctor/detect/ProjectDetector.java
@@ -1,0 +1,156 @@
+package com.falniak.devdoctor.detect;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Detects project types by scanning the filesystem for marker files.
+ */
+public class ProjectDetector {
+
+    /**
+     * Detects the project root and types starting from the given path.
+     *
+     * @param start The starting directory path
+     * @return DetectionResult containing the root path, detected types, and markers found
+     */
+    public DetectionResult detect(Path start) {
+        Path normalizedStart = start.toAbsolutePath().normalize();
+        Path root = findProjectRoot(normalizedStart);
+        Set<ProjectType> types = detectTypes(root);
+        List<String> markersFound = collectMarkers(root, types);
+        
+        return new DetectionResult(root, types, markersFound);
+    }
+
+    /**
+     * Walks up the directory tree to find the project root.
+     * A root is defined as a directory containing any known marker file.
+     *
+     * @param start The starting directory path
+     * @return The project root path, or the start path if no markers are found
+     */
+    public Path findProjectRoot(Path start) {
+        Path current = start.toAbsolutePath().normalize();
+        Path root = current.getRoot();
+
+        while (current != null && !current.equals(root)) {
+            if (hasAnyMarker(current)) {
+                return current;
+            }
+            Path parent = current.getParent();
+            if (parent == null || parent.equals(current)) {
+                break;
+            }
+            current = parent;
+        }
+
+        // If we reached the filesystem root without finding markers,
+        // return the original start directory
+        return start.toAbsolutePath().normalize();
+    }
+
+    /**
+     * Detects all project types present in the given root directory.
+     *
+     * @param root The root directory to scan
+     * @return A set of detected project types
+     */
+    public Set<ProjectType> detectTypes(Path root) {
+        Set<ProjectType> types = EnumSet.noneOf(ProjectType.class);
+
+        if (hasMarker(root, "pom.xml")) {
+            types.add(ProjectType.JAVA_MAVEN);
+        }
+
+        if (hasMarker(root, "build.gradle") || hasMarker(root, "build.gradle.kts")) {
+            types.add(ProjectType.JAVA_GRADLE);
+        }
+
+        if (hasMarker(root, "package.json")) {
+            types.add(ProjectType.NODE);
+        }
+
+        if (hasMarker(root, "docker-compose.yml") 
+            || hasMarker(root, "compose.yml") 
+            || hasMarker(root, "compose.yaml")) {
+            types.add(ProjectType.DOCKER_COMPOSE);
+        }
+
+        return types;
+    }
+
+    /**
+     * Checks if the given directory contains any known marker file.
+     *
+     * @param dir The directory to check
+     * @return true if any marker file exists
+     */
+    private boolean hasAnyMarker(Path dir) {
+        return hasMarker(dir, "pom.xml")
+            || hasMarker(dir, "build.gradle")
+            || hasMarker(dir, "build.gradle.kts")
+            || hasMarker(dir, "package.json")
+            || hasMarker(dir, "docker-compose.yml")
+            || hasMarker(dir, "compose.yml")
+            || hasMarker(dir, "compose.yaml");
+    }
+
+    /**
+     * Checks if a specific marker file exists in the given directory.
+     *
+     * @param dir The directory to check
+     * @param marker The marker file name
+     * @return true if the marker file exists and is a regular file
+     */
+    private boolean hasMarker(Path dir, String marker) {
+        Path markerPath = dir.resolve(marker);
+        return Files.exists(markerPath) && Files.isRegularFile(markerPath);
+    }
+
+    /**
+     * Collects the list of marker files that were found for the detected types.
+     *
+     * @param root The root directory
+     * @param types The detected project types
+     * @return List of marker file names that were found
+     */
+    private List<String> collectMarkers(Path root, Set<ProjectType> types) {
+        List<String> markers = new ArrayList<>();
+
+        if (types.contains(ProjectType.JAVA_MAVEN) && hasMarker(root, "pom.xml")) {
+            markers.add("pom.xml");
+        }
+
+        if (types.contains(ProjectType.JAVA_GRADLE)) {
+            if (hasMarker(root, "build.gradle")) {
+                markers.add("build.gradle");
+            }
+            if (hasMarker(root, "build.gradle.kts")) {
+                markers.add("build.gradle.kts");
+            }
+        }
+
+        if (types.contains(ProjectType.NODE) && hasMarker(root, "package.json")) {
+            markers.add("package.json");
+        }
+
+        if (types.contains(ProjectType.DOCKER_COMPOSE)) {
+            if (hasMarker(root, "docker-compose.yml")) {
+                markers.add("docker-compose.yml");
+            }
+            if (hasMarker(root, "compose.yml")) {
+                markers.add("compose.yml");
+            }
+            if (hasMarker(root, "compose.yaml")) {
+                markers.add("compose.yaml");
+            }
+        }
+
+        return markers;
+    }
+}

--- a/src/main/java/com/falniak/devdoctor/detect/ProjectType.java
+++ b/src/main/java/com/falniak/devdoctor/detect/ProjectType.java
@@ -1,0 +1,11 @@
+package com.falniak.devdoctor.detect;
+
+/**
+ * Represents different types of projects that can be detected.
+ */
+public enum ProjectType {
+    JAVA_MAVEN,
+    JAVA_GRADLE,
+    NODE,
+    DOCKER_COMPOSE
+}

--- a/src/test/java/com/falniak/devdoctor/detect/ProjectDetectorTest.java
+++ b/src/test/java/com/falniak/devdoctor/detect/ProjectDetectorTest.java
@@ -1,0 +1,186 @@
+package com.falniak.devdoctor.detect;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProjectDetectorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testFindRootWithMarkerInParent() throws Exception {
+        // Create structure: parent/pom.xml, parent/child/grandchild/
+        Path parent = tempDir.resolve("parent");
+        Path child = parent.resolve("child");
+        Path grandchild = child.resolve("grandchild");
+        Files.createDirectories(grandchild);
+        Files.createFile(parent.resolve("pom.xml"));
+
+        ProjectDetector detector = new ProjectDetector();
+        Path root = detector.findProjectRoot(grandchild);
+
+        assertEquals(parent, root);
+    }
+
+    @Test
+    void testDetectMaven() throws Exception {
+        Files.createFile(tempDir.resolve("pom.xml"));
+
+        ProjectDetector detector = new ProjectDetector();
+        DetectionResult result = detector.detect(tempDir);
+
+        assertTrue(result.types().contains(ProjectType.JAVA_MAVEN));
+        assertEquals(1, result.types().size());
+        assertTrue(result.markersFound().contains("pom.xml"));
+    }
+
+    @Test
+    void testDetectGradle() throws Exception {
+        Files.createFile(tempDir.resolve("build.gradle"));
+
+        ProjectDetector detector = new ProjectDetector();
+        DetectionResult result = detector.detect(tempDir);
+
+        assertTrue(result.types().contains(ProjectType.JAVA_GRADLE));
+        assertEquals(1, result.types().size());
+        assertTrue(result.markersFound().contains("build.gradle"));
+    }
+
+    @Test
+    void testDetectGradleKotlin() throws Exception {
+        Files.createFile(tempDir.resolve("build.gradle.kts"));
+
+        ProjectDetector detector = new ProjectDetector();
+        DetectionResult result = detector.detect(tempDir);
+
+        assertTrue(result.types().contains(ProjectType.JAVA_GRADLE));
+        assertEquals(1, result.types().size());
+        assertTrue(result.markersFound().contains("build.gradle.kts"));
+    }
+
+    @Test
+    void testDetectNode() throws Exception {
+        Files.createFile(tempDir.resolve("package.json"));
+
+        ProjectDetector detector = new ProjectDetector();
+        DetectionResult result = detector.detect(tempDir);
+
+        assertTrue(result.types().contains(ProjectType.NODE));
+        assertEquals(1, result.types().size());
+        assertTrue(result.markersFound().contains("package.json"));
+    }
+
+    @Test
+    void testDetectDockerCompose() throws Exception {
+        Files.createFile(tempDir.resolve("docker-compose.yml"));
+
+        ProjectDetector detector = new ProjectDetector();
+        DetectionResult result = detector.detect(tempDir);
+
+        assertTrue(result.types().contains(ProjectType.DOCKER_COMPOSE));
+        assertEquals(1, result.types().size());
+        assertTrue(result.markersFound().contains("docker-compose.yml"));
+    }
+
+    @Test
+    void testDetectDockerComposeYml() throws Exception {
+        Files.createFile(tempDir.resolve("compose.yml"));
+
+        ProjectDetector detector = new ProjectDetector();
+        DetectionResult result = detector.detect(tempDir);
+
+        assertTrue(result.types().contains(ProjectType.DOCKER_COMPOSE));
+        assertEquals(1, result.types().size());
+        assertTrue(result.markersFound().contains("compose.yml"));
+    }
+
+    @Test
+    void testDetectDockerComposeYaml() throws Exception {
+        Files.createFile(tempDir.resolve("compose.yaml"));
+
+        ProjectDetector detector = new ProjectDetector();
+        DetectionResult result = detector.detect(tempDir);
+
+        assertTrue(result.types().contains(ProjectType.DOCKER_COMPOSE));
+        assertEquals(1, result.types().size());
+        assertTrue(result.markersFound().contains("compose.yaml"));
+    }
+
+    @Test
+    void testDetectMultipleTypes() throws Exception {
+        Files.createFile(tempDir.resolve("pom.xml"));
+        Files.createFile(tempDir.resolve("package.json"));
+        Files.createFile(tempDir.resolve("docker-compose.yml"));
+
+        ProjectDetector detector = new ProjectDetector();
+        DetectionResult result = detector.detect(tempDir);
+
+        Set<ProjectType> types = result.types();
+        assertTrue(types.contains(ProjectType.JAVA_MAVEN));
+        assertTrue(types.contains(ProjectType.NODE));
+        assertTrue(types.contains(ProjectType.DOCKER_COMPOSE));
+        assertEquals(3, types.size());
+        assertEquals(3, result.markersFound().size());
+    }
+
+    @Test
+    void testNoMarkersReturnsStartDir() throws Exception {
+        // Create a nested directory structure without any markers
+        Path nested = tempDir.resolve("nested").resolve("deep");
+        Files.createDirectories(nested);
+
+        ProjectDetector detector = new ProjectDetector();
+        DetectionResult result = detector.detect(nested);
+
+        // Root should be the start directory (normalized)
+        assertEquals(nested.toAbsolutePath().normalize(), result.root());
+        assertTrue(result.types().isEmpty());
+        assertTrue(result.markersFound().isEmpty());
+    }
+
+    @Test
+    void testDetectTypesInCurrentDir() throws Exception {
+        Files.createFile(tempDir.resolve("pom.xml"));
+        Files.createFile(tempDir.resolve("package.json"));
+
+        ProjectDetector detector = new ProjectDetector();
+        Set<ProjectType> types = detector.detectTypes(tempDir);
+
+        assertTrue(types.contains(ProjectType.JAVA_MAVEN));
+        assertTrue(types.contains(ProjectType.NODE));
+        assertEquals(2, types.size());
+    }
+
+    @Test
+    void testFindProjectRootReturnsStartWhenNoMarkers() throws Exception {
+        Path start = tempDir.resolve("some").resolve("nested").resolve("path");
+        Files.createDirectories(start);
+
+        ProjectDetector detector = new ProjectDetector();
+        Path root = detector.findProjectRoot(start);
+
+        assertEquals(start.toAbsolutePath().normalize(), root);
+    }
+
+    @Test
+    void testGradleDetectsBothVariants() throws Exception {
+        Files.createFile(tempDir.resolve("build.gradle"));
+        Files.createFile(tempDir.resolve("build.gradle.kts"));
+
+        ProjectDetector detector = new ProjectDetector();
+        DetectionResult result = detector.detect(tempDir);
+
+        assertTrue(result.types().contains(ProjectType.JAVA_GRADLE));
+        assertEquals(1, result.types().size()); // Should only detect once
+        assertTrue(result.markersFound().contains("build.gradle"));
+        assertTrue(result.markersFound().contains("build.gradle.kts"));
+        assertEquals(2, result.markersFound().size());
+    }
+}


### PR DESCRIPTION
## Summary
Implements real project detection for `devdoctor detect`.

## What’s included
- Added `ProjectDetector` that walks up directories to find the nearest project root based on marker files
- Added `ProjectType` and `DetectionResult` models
- Updated `detect` command to print root and detected types
- Added a comprehensive JUnit test suite for detector behavior (root discovery, single/multiple markers, no-marker fallback)

## Supported markers (v0.1)
- Maven: `pom.xml`
- Gradle: `build.gradle`, `build.gradle.kts`
- Node: `package.json`
- Docker Compose: `docker-compose.yml`, `compose.yml`, `compose.yaml`

## Verification
- `mvn test`
- `mvn package`
- `java -jar target/devdoctor.jar detect`
